### PR TITLE
Fixed order of topological sort

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -178,6 +178,7 @@ export function getActions(config: Config, actionToRun: string, groupToRun: stri
 	 * In order to avoid having multiple iterations, we sort the actions topologically first to ensure the dependencies are always resolved.
 	 */
 	topologicalSortActionGraph(config, actionToRun)
+		.reverse()
 		.filter((action) => !config.projects[action].actions[actionToRun]?.groups[groupToRun])
 		.forEach((actionNoGroup) => {
 			// Find all actions that needs this action, remove this action from the needs list, and replace it with the needs of this action


### PR DESCRIPTION
If d needed c, which needed b which needed a, and b and c did not have the group specified, d would be mapped to need b, which is wrong.

Instead d should need a.